### PR TITLE
Increase job timeout for bioblend tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ install:
 	sudo su $(GALAXY_TRAVIS_USER) -c 'pip install --user --upgrade "tox>=1.8.0" "pep8<=1.6.2" six '
 	cd $(GALAXY_HOME)/bioblend-master && sudo su $(GALAXY_TRAVIS_USER) -c 'python setup.py install --user'
 	# remove flake8 testing for bioblend from tox
-	cd $(GALAXY_HOME)/bioblend-master && sudo su $(GALAXY_TRAVIS_USER) -c "sed -i 's/commands.*$$/commands =/' tox.ini"
+	cd $(GALAXY_HOME)/bioblend-master && sudo su $(GALAXY_TRAVIS_USER) -c "sed -i 's/commands.*$$/commands =/' tox.ini" && sudo su $(GALAXY_TRAVIS_USER) -c "sed -i 's/GALAXY_VERSION/GALAXY_VERSION BIOBLEND_TEST_JOB_TIMEOUT/' tox.ini"
 
 test_api:
 	curl --fail $(BIOBLEND_GALAXY_URL)/api/version
@@ -62,7 +62,7 @@ test_ftp:
 test_bioblend:
 	# Run bioblend nosetests with the same UID and GID as the galaxy user inside if Docker
 	# this will guarantee that exchanged files bewteen bioblend and Docker are read & writable from both sides
-	sudo -E su $(GALAXY_TRAVIS_USER) -c "export BIOBLEND_GALAXY_API_KEY=admin && export BIOBLEND_GALAXY_URL=http://localhost:8080 && export PATH=$(GALAXY_HOME)/.local/bin/:$(PATH) && cd $(GALAXY_HOME)/bioblend-master && tox -e $(TOX_ENV) -- -k 'not download_dataset and not download_history and not export_and_download'"
+	sudo -E su $(GALAXY_TRAVIS_USER) -c "export BIOBLEND_GALAXY_API_KEY=admin && export BIOBLEND_GALAXY_URL=http://localhost:8080 && export BIOBLEND_TEST_JOB_TIMEOUT=240 && export PATH=$(GALAXY_HOME)/.local/bin/:$(PATH) && cd $(GALAXY_HOME)/bioblend-master && tox -e $(TOX_ENV) -- -k 'not download_dataset and not download_history and not export_and_download'"
 
 test_docker_in_docker:	
 	# Test Docker in Docker, used by Interactive Environments; This needs to be at the end as Docker takes some time to start.


### PR DESCRIPTION
Should fix travis errors in https://github.com/galaxy-genome-annotation/docker-galaxy-genome-annotation/pull/32
Same change as in https://github.com/bgruening/docker-galaxy-stable/commit/1cf32151926fa670f8b6e9f8e61e01b68f22c810#diff-c5e05a31e76f346b32fdb1f3a024e819