### PR TITLE
Fix "executable file not found" with 19.05

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ docker_run:
 		-v /tmp/:/tmp/ \
 		galaxy-docker/test
 	docker ps
-	docker exec -i -t galaxy_test_container galaxy-wait -v
+	docker exec -i -t galaxy_test_container /tool_deps/_conda/bin/galaxy-wait -v
 
 sleep:
 	sleep 60


### PR DESCRIPTION
This should fix the error in https://travis-ci.org/galaxy-genome-annotation/docker-galaxy-genome-annotation/builds/594492494
I wonder if we should add /tool_deps/_conda/bin/ to root's PATH (but I'm little frightened it would break other things...)