### PR TITLE
Update default password/apikey for 20.05

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ GALAXY_GID:=1450
 GALAXY_HOME:=/home/galaxy
 GALAXY_USER:=admin@galaxy.org
 GALAXY_USER_EMAIL:=admin@galaxy.org
-GALAXY_USER_PASSWD:=admin
-BIOBLEND_GALAXY_API_KEY:=admin
+GALAXY_USER_PASSWD:=password
+BIOBLEND_GALAXY_API_KEY:=fakekey
 BIOBLEND_GALAXY_URL:=http://localhost:8080
 
 
@@ -62,7 +62,7 @@ test_ftp:
 test_bioblend:
 	# Run bioblend nosetests with the same UID and GID as the galaxy user inside if Docker
 	# this will guarantee that exchanged files bewteen bioblend and Docker are read & writable from both sides
-	sudo -E su $(GALAXY_TRAVIS_USER) -c "export BIOBLEND_GALAXY_API_KEY=admin && export BIOBLEND_GALAXY_URL=http://localhost:8080 && export BIOBLEND_TEST_JOB_TIMEOUT=240 && export PATH=$(GALAXY_HOME)/.local/bin/:$(PATH) && cd $(GALAXY_HOME)/bioblend-master && tox -e $(TOX_ENV) -- -k 'not download_dataset and not download_history and not export_and_download'"
+	sudo -E su $(GALAXY_TRAVIS_USER) -c "export BIOBLEND_GALAXY_API_KEY=fakekey && export BIOBLEND_GALAXY_URL=http://localhost:8080 && export BIOBLEND_TEST_JOB_TIMEOUT=240 && export PATH=$(GALAXY_HOME)/.local/bin/:$(PATH) && cd $(GALAXY_HOME)/bioblend-master && tox -e $(TOX_ENV) -- -k 'not download_dataset and not download_history and not export_and_download'"
 
 test_docker_in_docker:	
 	# Test Docker in Docker, used by Interactive Environments; This needs to be at the end as Docker takes some time to start.


### PR DESCRIPTION
That should fix the [error for the GGA flavor](https://travis-ci.org/github/galaxy-genome-annotation/docker-galaxy-genome-annotation/builds/703554849)
On the other hand, it's a breaking change that will make the tests fail for flavors based on older version... Hum, should we care?