### PR TITLE
fix python version for bioblend

### DIFF
--- a/example_circleci_config.yml
+++ b/example_circleci_config.yml
@@ -16,17 +16,17 @@ jobs:
           command: |
                make install
       - run:
-          name: Run tests 
-          command: |   
+          name: Run tests
+          command: |
                make test_api
                make test_ftp
                #make test_bioblend
           environment:
-               TOX_ENV: py27
+               TOX_ENV: py37
       - run:
           name: push image
           command: |
             set -x
             sh +x -c 'echo $QUAY_TOKEN' | docker login -u=$QUAY_USERNAME --password-stdin quay.io
-            docker tag galaxy-docker/test quay.io/bgruening/galaxy-rna-seq:circle 
+            docker tag galaxy-docker/test quay.io/bgruening/galaxy-rna-seq:circle
             docker push quay.io/bgruening/galaxy-rna-seq:circle

--- a/example_circleci_config_w_caching_and_push.yml
+++ b/example_circleci_config_w_caching_and_push.yml
@@ -43,7 +43,7 @@ jobs:
                make test_ftp
                make test_bioblend
           environment:
-               TOX_ENV: py27
+               TOX_ENV: py37
       - deploy:
           name: Push application Docker image
           command: |

--- a/example_travis.yml
+++ b/example_travis.yml
@@ -1,13 +1,13 @@
 sudo: required
 
 language: python
-python: 2.7
+python: 3.7
 
 services:
   - docker
 
 env:
-  - TOX_ENV=py27
+  - TOX_ENV=py37
 
 git:
   submodules: false


### PR DESCRIPTION
Fix this:
```
$ make test_bioblend

# Run bioblend nosetests with the same UID and GID as the galaxy user inside if Docker

# this will guarantee that exchanged files bewteen bioblend and Docker are read & writable from both sides

sudo -E su galaxy -c "export BIOBLEND_GALAXY_API_KEY=fakekey && export BIOBLEND_GALAXY_URL=http://localhost:8080 && export BIOBLEND_TEST_JOB_TIMEOUT=240 && export PATH=/home/galaxy/.local/bin/:/home/travis/virtualenv/python2.7.15/bin:/home/travis/bin:/home/travis/.local/bin:/usr/local/lib/jvm/openjdk11/bin:/opt/pyenv/shims:/home/travis/.phpenv/shims:/home/travis/perl5/perlbrew/bin:/home/travis/.nvm/versions/node/v8.12.0/bin:/home/travis/.rvm/gems/ruby-2.5.3/bin:/home/travis/.rvm/gems/ruby-2.5.3@global/bin:/home/travis/.rvm/rubies/ruby-2.5.3/bin:/home/travis/gopath/bin:/home/travis/.gimme/versions/go1.11.1.linux.amd64/bin:/usr/local/maven-3.6.3/bin:/usr/local/cmake-3.12.4/bin:/usr/local/clang-7.0.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/home/travis/.rvm/bin:/home/travis/.phpenv/bin:/opt/pyenv/bin:/home/travis/.yarn/bin && cd /home/galaxy/bioblend-master && tox -e py27 -- -k 'not download_dataset and not download_history and not export_and_download'"

GLOB sdist-make: /home/galaxy/bioblend-master/setup.py

py27 create: /home/galaxy/bioblend-master/.tox/py27

py27 inst: /home/galaxy/bioblend-master/.tox/.tmp/package/1/bioblend-0.14.0.zip

ERROR: invocation failed (exit code 1), logfile: /home/galaxy/bioblend-master/.tox/py27/log/py27-1.log

================================== log start ===================================

DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support

Processing ./.tox/.tmp/package/1/bioblend-0.14.0.zip

ERROR: Package 'bioblend' requires a different Python: 2.7.12 not in '>=3.5'

=================================== log end ====================================

___________________________________ summary ____________________________________

ERROR:   py27: InvocationError for command /home/galaxy/bioblend-master/.tox/py27/bin/python -m pip install --exists-action w .tox/.tmp/package/1/bioblend-0.14.0.zip (exited with code 1)

Makefile:63: recipe for target 'test_bioblend' failed

make: *** [test_bioblend] Error 1

The command "make test_bioblend" exited with 2.

Done. Your build exited with 1.
```